### PR TITLE
Reenable variable renaming

### DIFF
--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -269,9 +269,9 @@ endfunction
 
 function! s:call_rename_variable(new_name, line, col, search_path)
     let file = expand("%:p")
-    let module = "api_wrangler"
+    let module = "refac_rename_var"
     let fun = "rename_var"
-    let args = '["'. file .'",'.a:line.','.a:col.',"'.a:new_name.'", ["'. a:search_path .'"] ]'
+    let args = '["'. file .'",'.a:line.','.a:col.',"'.a:new_name.'", ["'. a:search_path .'"], command, 8 ]'
     let result = s:send_rpc(module, fun, args)
 
     let [error_code, msg] = s:check_for_error(result)


### PR DESCRIPTION
The function for this is no longer in the API it appears. The prompt is still kind of wrong (shows `Rename Headers variable to: Headers "undef` with a trailing `"undef`), but I'm not quite sure how to fix this yet.
