### PR TITLE
Use call command to shutdown wrangler server

### DIFF
--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -86,7 +86,7 @@ endfunction
 function! StopWranglerServer()
     if (s:wrangler_node_started == 1)
         let command = s:erl_call_cmd." -name " . s:erlangServerName . " -a 'erlang halt'"
-        system(command)
+        call system(command)
     endif
 endfunction
 


### PR DESCRIPTION
When calling `:call StopWranglerServer()` manually, I receive the following error message (ArchLinux, vim 8.0):

```
Error detected while processing function StopWranglerServer:
line    3:
E492: Not an editor command:         system(command)
```

This pull request fixes this issue by calling `system()` with `call`. This is how it is done in `StartWranglerServer()`.